### PR TITLE
Update EncyclopeDIA DLIB writer

### DIFF
--- a/ms2ml/data/parsing/encyclopedia.py
+++ b/ms2ml/data/parsing/encyclopedia.py
@@ -203,9 +203,10 @@ def write_encyclopedia(
             """
 
         # Add spectra in batches of 100k. This is arbitrary.
-        if num_spectra % 100000:
+        if not num_spectra % 100000:
             con.executemany(spec_query, spec_to_add)
             con.commit()
+            spec_to_add = []
 
     # Commit any remaining:
     if spec_to_add:

--- a/tests/test_encyclopedia.py
+++ b/tests/test_encyclopedia.py
@@ -44,6 +44,17 @@ def test_writing_encyclopedia(tmp_path):
 
     assert i == 1
 
+    # Try appending more specs:
+    write_encyclopedia(tmp_path / "test.dlib", specs)
+    adapter = EncyclopeDIAAdapter(tmp_path / "test.dlib", config=Config())
+    for i, spec in enumerate(adapter.parse()):
+        print(spec)
+        assert isinstance(spec, AnnotatedPeptideSpectrum)
+        assert np.all(spec.mz >= 0)
+        assert np.all(spec.intensity >= 0)
+
+    assert i == 3
+
 
 def test_mokapot_encyclopedia_export(shared_datadir, tmp_path):
     peptides_path = shared_datadir / "mokapot/mokapot.peptides.txt"

--- a/tests/test_encyclopedia.py
+++ b/tests/test_encyclopedia.py
@@ -18,7 +18,7 @@ def test_encyclopedia_adapter(shared_datadir):
         assert np.all(spec.intensity >= 0)
 
 
-def test_enciclopedia_decoding():
+def test_encyclopedia_decoding():
     mass_enc_len = 48
     mass_enc = b"x\x9c\x010\x00\xcf\xff@vq\xeat\x91\xe7\r@w\xd3iu3!\xaf@~\xe4\xc1\xc8\xacy\x12@\x84\x8a\xe2\x96\xba\xb9q@\x8a[\x85\x05\x90\x04<@\x8d\xf3\xbc3xI\xe0@>\x17Q"  # noqa
     mass_dec = _extract_array(mass_enc, "d")
@@ -32,11 +32,12 @@ def test_enciclopedia_decoding():
     assert len(int_dec) * 4 == int_enc_len
 
 
-def test_writting_enciclopedia(tmpdir):
+def test_writing_encyclopedia(tmp_path):
     specs = [AnnotatedPeptideSpectrum._sample(), AnnotatedPeptideSpectrum._sample()]
-    write_encyclopedia(tmpdir / "test.dlib", specs)
-    adapter = EncyclopeDIAAdapter(tmpdir / "test.dlib", config=Config())
+    write_encyclopedia(tmp_path / "test.dlib", specs)
+    adapter = EncyclopeDIAAdapter(tmp_path / "test.dlib", config=Config())
     for i, spec in enumerate(adapter.parse()):
+        print(spec)
         assert isinstance(spec, AnnotatedPeptideSpectrum)
         assert np.all(spec.mz >= 0)
         assert np.all(spec.intensity >= 0)
@@ -44,7 +45,7 @@ def test_writting_enciclopedia(tmpdir):
     assert i == 1
 
 
-def test_mokapot_enciclopedia_export(shared_datadir, tmp_path):
+def test_mokapot_encyclopedia_export(shared_datadir, tmp_path):
     peptides_path = shared_datadir / "mokapot/mokapot.peptides.txt"
     lookup_path = shared_datadir / "mzml/"
     output_path = tmp_path / "encyclopedia.dlib"
@@ -59,7 +60,7 @@ def test_mokapot_enciclopedia_export(shared_datadir, tmp_path):
     adapter = MokapotPSMAdapter(
         config=config, file=peptides_path, raw_file_locations=lookup_path
     )
-    write_encyclopedia(file=output_path, spectra=adapter.parse())
+    write_encyclopedia(lib_file=output_path, spectra=adapter.parse())
 
     con = sqlite3.connect(output_path)
     p2p_out = pd.read_sql_query("SELECT * FROM peptidetoprotein", con)


### PR DESCRIPTION
This PR makes a few changes:

- Change the `file` parameter to `dlib_file` to prevent collision with the default namespace.
- Allows spectra to be appended to the same DLIB file. This is useful if you have spectra coming from multiple source files and we want accurately reflect that.
- Adds and commits spectra in batches, which should be significantly faster than doing one by one.